### PR TITLE
grpcWSGI can be pip installed now

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
   grpcwsgi:
     build:
       context: ./
-      dockerfile: ./backend/grpcwsgi/Dockerfile
+      dockerfile: ./proxy/grpcwsgi/Dockerfile
     ports:
       - '8080:8080'
   improbable:

--- a/proxy/grpcwsgi/Dockerfile
+++ b/proxy/grpcwsgi/Dockerfile
@@ -6,15 +6,14 @@ COPY . .
 
 RUN ls -l
 
-RUN pip install git+git://github.com/public/grpcWSGI.git
-RUN pip install grpcio-tools
+RUN pip install grpcio-tools grpcWSGI
 
 RUN python -m grpc.tools.protoc \
     --proto_path=proto/echo \
-    --python_out=backend/grpcwsgi/ \
-    --grpc_python_out=backend/grpcwsgi/ \
+    --python_out=proxy/grpcwsgi/ \
+    --grpc_python_out=proxy/grpcwsgi/ \
     proto/echo/echo.proto
 
 EXPOSE 10000
 
-CMD [ "python", "./backend/grpcwsgi/server.py" ]
+CMD [ "python", "./proxy/grpcwsgi/server.py" ]


### PR DESCRIPTION
This is pip installable now, and also I fixed a bit we missed after this got moved to the proxy folder.