### PR TITLE
Don't check for end events.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
   inprocess-grpcWeb-chrome:
     <<: *golang-template-job
 
-  xfail-inprocess-grpcWebText-chrome:
+  inprocess-grpcWebText-chrome:
     <<: *golang-template-job
 
   grpcwebproxy-improbable-chrome:
@@ -34,7 +34,7 @@ jobs:
   grpcwebproxy-grpcWeb-chrome:
     <<: *golang-template-job
 
-  xfail-grpcwebproxy-grpcWebText-chrome:
+  grpcwebproxy-grpcWebText-chrome:
     <<: *golang-template-job
 
   envoy-template-job: &envoy-template-job
@@ -48,7 +48,7 @@ jobs:
   envoy-grpcWeb-chrome:
     <<: *envoy-template-job
 
-  xfail-envoy-grpcWebText-chrome:
+  envoy-grpcWebText-chrome:
     <<: *envoy-template-job
 
   grpcwsgi-template-job: &grpcwsgi-template-job
@@ -69,13 +69,13 @@ workflows:
       - inprocess-improbable-chrome
       - xfail-inprocess-improbableWS-chrome
       - inprocess-grpcWeb-chrome
-      - xfail-inprocess-grpcWebText-chrome
+      - inprocess-grpcWebText-chrome
       - grpcwebproxy-improbable-chrome
       - grpcwebproxy-improbableWS-chrome
       - grpcwebproxy-grpcWeb-chrome
-      - xfail-grpcwebproxy-grpcWebText-chrome
+      - grpcwebproxy-grpcWebText-chrome
       - envoy-improbable-chrome
       - envoy-grpcWeb-chrome
-      - xfail-envoy-grpcWebText-chrome
+      - envoy-grpcWebText-chrome
       - xfail-grpcwsgi-improbable-chrome
       - xfail-grpcwsgi-grpcWeb-chrome

--- a/frontend/grpcWeb/grpcWebSpec.ts
+++ b/frontend/grpcWeb/grpcWebSpec.ts
@@ -65,9 +65,6 @@ describe("grpc client", function () {
 
     srv.on("status", function (status: grpcWeb.Status) {
       assert(status.code == grpcWeb.StatusCode.OK);
-    });
-
-    srv.on("end", function () {
       assert(recvCount == 5);
       done();
     });

--- a/frontend/improbable/improbableGrpcSpec.ts
+++ b/frontend/improbable/improbableGrpcSpec.ts
@@ -73,9 +73,6 @@ describe('grpc client', function () {
 
     srv.on("status", function (status: Status) {
       assert(status.code == grpc.Code.OK);
-    });
-
-    srv.on("end", function () {
       assert(recvCount == 5);
       done();
     });

--- a/frontend/improbableWS/improbableWsGrpcSpec.ts
+++ b/frontend/improbableWS/improbableWsGrpcSpec.ts
@@ -72,9 +72,7 @@ describe('grpc client', function () {
 
     srv.on("status", function (status: Status) {
       assert(status.code == grpc.Code.OK);
-    });
-
-    srv.on("end", function () {
+      assert(recvCount == 5);
       done();
     });
   });


### PR DESCRIPTION
Fixes #13.

I've applied this change to all implementations since the semantics of the end event aren't documented  and I can't think of a reason why they would be any different to status.