### PR TITLE
Add akka-grpc backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Test various implementations of gRPC-Web Clients with various implementations of
   The same as `grpcwebproxy`, but running as an in-process proxy to a Go gRPC
   server.
 
+- `akkagrpc`
+
+  An example server built using the Akka gRPC library, which
+  [supports gRPC-Web natively](https://doc.akka.io/docs/akka-grpc/current/server/grpc-web.html)
+  without a proxy, available at https://github.com/akka/akka-grpc.
+
 - `envoy`
 
   The Envoy Proxy HTTP filter implementation created for the `grpc/grpc-web` project,
@@ -78,6 +84,7 @@ the `echo-server` container on up.
 
 | Proxy / Client | `improbable` | `grpcWeb` | `grpcWebText` | `improbableWS` [1] |
 | -------------- | ------------ | --------- | ------------- | ------------------- |
+| `akkagrpc`     | ✔️           | ✔️️       | ✔️            | ❌                   |
 | `envoy`        | ✔️           | ✔️️       | ✔️            | ❌                   |
 | `grpcwebproxy` | ✔️️          | ✔️        | ✔️            | ✔️️                 |
 | `inprocess`    | ✔️️          | ✔️        | ✔️            | ✔️️                 |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,12 @@ services:
       dockerfile: ./proxy/grpcwsgi/Dockerfile
     ports:
       - '8080:8080'
+  akkagrpc:
+    build:
+      context: ./
+      dockerfile: ./proxy/akkagrpc/Dockerfile
+    ports:
+      - '8080:8080'
   frontend:
     build:
       context: ./frontend

--- a/proxy/akkagrpc/Dockerfile
+++ b/proxy/akkagrpc/Dockerfile
@@ -1,0 +1,20 @@
+FROM adoptopenjdk:8-jdk-hotspot
+
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+RUN apt-get update && \
+	apt-get -qq -y install curl wget unzip zip
+
+RUN curl -s "https://get.sdkman.io" | bash
+RUN source "$HOME/.sdkman/bin/sdkman-init.sh"; sdk install sbt 1.3.8
+RUN $HOME/.sdkman/candidates/sbt/current/bin/sbt --version
+
+COPY proxy/akkagrpc/build.sbt /akka-grpc/build.sbt
+COPY proxy/akkagrpc/project/ /akka-grpc/project
+COPY proto/ /akka-grpc/src/main/protobuf
+COPY vendor/github.com/golang/protobuf/ptypes/duration/duration.proto /akka-grpc/src/main/protobuf/google/protobuf/duration.proto
+COPY proxy/akkagrpc/src /akka-grpc/src
+
+WORKDIR /akka-grpc
+RUN $HOME/.sdkman/candidates/sbt/current/bin/sbt compile
+
+CMD $HOME/.sdkman/candidates/sbt/current/bin/sbt run

--- a/proxy/akkagrpc/build.sbt
+++ b/proxy/akkagrpc/build.sbt
@@ -1,0 +1,13 @@
+enablePlugins(AkkaGrpcPlugin)
+
+libraryDependencies += "ch.megard" %% "akka-http-cors" % "0.4.2"
+
+
+lazy val root = (project in file("."))
+  .settings(
+    inThisBuild(List(
+      organization := "test",
+      scalaVersion := "2.13.1"
+    )),
+    name := "Akka gRPC Compatibility Test"
+  )

--- a/proxy/akkagrpc/project/plugins.sbt
+++ b/proxy/akkagrpc/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.8.1")

--- a/proxy/akkagrpc/src/main/scala/Main.scala
+++ b/proxy/akkagrpc/src/main/scala/Main.scala
@@ -1,0 +1,30 @@
+import akka.actor.ActorSystem
+import akka.grpc.scaladsl.WebHandler
+import akka.http.scaladsl.{ Http, HttpConnectionContext }
+import akka.stream.{ ActorMaterializer, Materializer }
+import com.typesafe.config.ConfigFactory
+
+import grpc.gateway.testing._
+import grpc.gateway.testing.impl.EchoServiceImpl
+
+import scala.concurrent.ExecutionContext
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    val conf = ConfigFactory
+      .parseString("akka.http.server.preview.enable-http2 = on")
+      .withFallback(ConfigFactory.defaultApplication())
+
+    implicit val sys: ActorSystem = ActorSystem("HelloWorld", conf)
+    implicit val mat: Materializer = ActorMaterializer()
+    implicit val ec: ExecutionContext = sys.dispatcher
+
+    Http()
+      .bindAndHandleAsync(
+        WebHandler.grpcWebHandler(EchoServiceHandler.partial(new EchoServiceImpl())),
+        interface = "0.0.0.0",
+        port = 8080,
+        connectionContext = HttpConnectionContext())
+        .foreach { binding => println(s"gRPC-Web server bound to: ${binding.localAddress}") }
+	}
+}

--- a/proxy/akkagrpc/src/main/scala/grpc/gateway/testing/impl/EchoServiceImpl.scala
+++ b/proxy/akkagrpc/src/main/scala/grpc/gateway/testing/impl/EchoServiceImpl.scala
@@ -1,0 +1,89 @@
+package grpc.gateway.testing.impl
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.grpc.GrpcServiceException
+import akka.stream.Materializer
+import akka.stream.scaladsl.{ Keep, Sink, Source }
+import com.google.protobuf.duration.Duration
+import grpc.gateway.testing._
+import io.grpc.Status
+import scala.concurrent.{ ExecutionContext, Future }
+
+class EchoServiceImpl(implicit actorSystem: ActorSystem, mat: Materializer) extends EchoService {
+  import actorSystem.dispatcher
+
+  /**
+   * One request followed by one response
+   * The server returns the client message as-is.
+   */
+  override def echo(in: EchoRequest): Future[EchoResponse] = Future.successful(EchoResponse(in.message))
+
+  /**
+   * Sends back abort status.
+   */
+  override def echoAbort(in: EchoRequest): Future[EchoResponse] = throw new GrpcServiceException(Status.ABORTED)
+
+  /**
+   * One empty request, ZERO processing, followed by one empty response
+   * (minimum effort to do message serialization).
+   */
+  override def noOp(in: Empty): Future[Empty] = Future.successful(Empty())
+
+  /**
+   * One request followed by a sequence of responses (streamed download).
+   * The server will return the same client message repeatedly.
+   */
+  override def serverStreamingEcho(in: ServerStreamingEchoRequest): Source[ServerStreamingEchoResponse, NotUsed] = {
+    import scala.concurrent.duration._
+    val interval = in.messageInterval.map(toFiniteDuration).getOrElse(100.millis)
+    Source
+      .tick(interval, interval, ServerStreamingEchoResponse(in.message))
+      .take(in.messageCount)
+      .mapMaterializedValue(_ => NotUsed)
+  }
+
+  implicit def toFiniteDuration(d: Duration) = {
+    import scala.concurrent.duration._
+    d.nanos.nanos + d.seconds.seconds
+  }
+
+  /**
+   * One request followed by a sequence of responses (streamed download).
+   * The server abort directly.
+   */
+  override def serverStreamingEchoAbort(in: ServerStreamingEchoRequest): Source[ServerStreamingEchoResponse, NotUsed] =
+    Source
+      .single(ServerStreamingEchoResponse(in.message))
+      .concat(Source.failed(new GrpcServiceException(Status.ABORTED)))
+
+  /**
+   * A sequence of requests followed by one response (streamed upload).
+   * The server returns the total number of messages as the result.
+   */
+  override def clientStreamingEcho(
+      in: Source[ClientStreamingEchoRequest, NotUsed]): Future[ClientStreamingEchoResponse] =
+    in.toMat(Sink.fold(0) { case (current, _) => current + 1 })(Keep.right).run().map(ClientStreamingEchoResponse(_))
+
+  /**
+   * A sequence of requests with each message echoed by the server immediately.
+   * The server returns the same client messages in order.
+   * E.g. this is how the speech API works.
+   */
+  override def fullDuplexEcho(in: Source[EchoRequest, NotUsed]): Source[EchoResponse, NotUsed] =
+    in.map(in => EchoResponse(in.message))
+
+  /**
+   * A sequence of requests followed by a sequence of responses.
+   * The server buffers all the client messages and then returns the same
+   * client messages one by one after the client half-closes the stream.
+   * This is how an image recognition API may work.
+   */
+  override def halfDuplexEcho(in: Source[EchoRequest, NotUsed]): Source[EchoResponse, NotUsed] = {
+    Source
+      .fromFutureSource(
+        in.toMat(Sink.collection)(Keep.right).run().map(reqs => Source.fromIterator(() => reqs.iterator)))
+      .map(in => EchoResponse(in.message))
+      .mapMaterializedValue(_ => NotUsed)
+  }
+}


### PR DESCRIPTION
Akka-gRPC is a library that supports gRPC-Web natively (since 0.8), so this builds and runs an example Akka Http server that hosts a native Akka gRPC implementation of the EchoService.

The backend is implemented as a minimal Scala app that starts Akka HTTP to host an implementation of EchoService in Scala/AkkaGrpc/AkkaStreams.

Passes tests against improbable, grpcWeb and grpcWebText front-ends.